### PR TITLE
Implement connection pooling and fix process-local messages

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -15,6 +15,81 @@ from channels.exceptions import ChannelFull
 from channels.layers import BaseChannelLayer
 
 
+class ConnectionPool:
+    """
+    Connection pool manager for the channel layer.
+
+    It manages a set of connections for the given host specification and
+    taking into account asyncio event loops.
+    """
+
+    def __init__(self, host):
+        self.host = host
+        self.conn_map = {}
+        self.in_use = {}
+
+    def _ensure_loop(self, loop):
+        """
+        Get connection list for the specified loop.
+        """
+        if loop is None:
+            loop = asyncio.get_event_loop()
+
+        if loop not in self.conn_map:
+            self.conn_map[loop] = []
+
+        return self.conn_map[loop], loop
+
+    async def pop(self, loop=None):
+        """
+        Get a connection for the given identifier and loop.
+        """
+        conns, loop = self._ensure_loop(loop)
+        if not conns:
+            conns.append(await aioredis.create_redis(**self.host, loop=loop))
+        conn = conns.pop()
+        self.in_use[conn] = loop
+        return conn
+
+    def push(self, conn):
+        """
+        Return a connection to the pool.
+        """
+        loop = self.in_use[conn]
+        del self.in_use[conn]
+        conns, _ = self._ensure_loop(loop)
+        conns.append(conn)
+
+    def conn_error(self, conn):
+        """
+        Handle a connection that produced an error.
+        """
+        conn.close()
+        del self.in_use[conn]
+
+    def reset(self):
+        """
+        Clear all connections from the pool.
+        """
+        self.conn_map = {}
+        self.in_use = {}
+
+    async def close(self):
+        """
+        Close all connections owned by the pool.
+        """
+        conn_map = self.conn_map
+        in_use = self.in_use
+        self.reset()
+        for conns in conn_map.values():
+            for conn in conns:
+                conn.close()
+                await conn.wait_closed()
+        for conn in in_use:
+            conn.close()
+            await conn.wait_closed()
+
+
 class UnsupportedRedis(Exception):
     pass
 
@@ -48,12 +123,11 @@ class RedisChannelLayer(BaseChannelLayer):
         self.channel_capacity = self.compile_capacities(channel_capacity or {})
         self.prefix = prefix
         assert isinstance(self.prefix, str), "Prefix must be unicode"
-        # Cached redis connection pools and the event loop they are from
-        self.pools = {}
-        self.pools_loop = None
         # Configure the host objects
         self.hosts = self.decode_hosts(hosts)
         self.ring_size = len(self.hosts)
+        # Cached redis connection pools and the event loop they are from
+        self.pools = [ConnectionPool(host) for host in self.hosts]
         # Normal channels choose a host index by cycling through the available hosts
         self._receive_index_generator = itertools.cycle(range(len(self.hosts)))
         self._send_index_generator = itertools.cycle(range(len(self.hosts)))
@@ -262,6 +336,15 @@ class RedisChannelLayer(BaseChannelLayer):
                     keys=[],
                     args=[self.prefix + "*"]
                 )
+        # Now clear the pools as well
+        await self.close_pools()
+
+    async def close_pools(self):
+        """
+        Close all connections in the event loop pools.
+        """
+        for pool in self.pools:
+            await pool.close()
 
     ### Groups extension ###
 
@@ -433,19 +516,23 @@ class RedisChannelLayer(BaseChannelLayer):
         if not 0 <= index < self.ring_size:
             raise ValueError("There are only %s hosts - you asked for %s!" % (self.ring_size, index))
         # Make a context manager
-        return self.ConnectionContextManager(self.hosts[index])
+        return self.ConnectionContextManager(self.pools[index])
 
     class ConnectionContextManager:
         """
         Async context manager for connections
         """
 
-        def __init__(self, kwargs):
-            self.kwargs = kwargs
+        def __init__(self, pool):
+            self.pool = pool
 
         async def __aenter__(self):
-            self.conn = await aioredis.create_redis(**self.kwargs)
+            self.conn = await self.pool.pop()
             return self.conn
 
         async def __aexit__(self, exc_type, exc, tb):
-            self.conn.close()
+            if exc:
+                self.pool.conn_error(self.conn)
+            else:
+                self.pool.push(self.conn)
+            self.conn = None

--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -104,7 +104,6 @@ class RedisChannelLayer(BaseChannelLayer):
     """
 
     blpop_timeout = 5
-    queue_get_timeout = 10
 
     def __init__(
         self,
@@ -138,10 +137,11 @@ class RedisChannelLayer(BaseChannelLayer):
         self._setup_encryption(symmetric_encryption_keys)
         # Number of coroutines trying to receive right now
         self.receive_count = 0
+        # The receiving token queue
+        # Whoever holds its tokens can receive from a local channel
+        self.receive_tokens = None
         # Event loop they are trying to receive on
         self.receive_event_loop = None
-        # Main receive loop running
-        self.receive_loop_task = None
         # Buffered messages by process-local channel name
         self.receive_buffer = collections.defaultdict(asyncio.Queue)
 
@@ -231,50 +231,39 @@ class RedisChannelLayer(BaseChannelLayer):
             self.receive_count += 1
             try:
                 if self.receive_count == 1:
-                    # If we're the first coroutine in, make a receive loop!
-                    general_channel = self.non_local_name(channel)
-                    self.receive_loop_task = loop.create_task(self.receive_loop(general_channel))
+                    # If we're the first coroutine in, create the sharing token!
+                    self.receive_tokens = asyncio.Queue()
+                    self.receive_tokens.put_nowait(True)
                     self.receive_event_loop = loop
                 else:
                     # Otherwise, check our event loop matches
                     if self.receive_event_loop != loop:
                         raise RuntimeError("Two event loops are trying to receive() on one channel layer at once!")
-                    if self.receive_loop_task.done():
-                        # Maybe raise an exception from the task
-                        self.receive_loop_task.result()
-                        # Raise our own exception if that failed
-                        raise RuntimeError("Redis receive loop exited early")
 
                 # Wait for our message to appear
-                while True:
+                while self.receive_buffer[channel].empty():
+                    token = await self.receive_tokens.get()
                     try:
-                        message = await asyncio.wait_for(self.receive_buffer[channel].get(), self.queue_get_timeout)
-                        if self.receive_buffer[channel].empty():
-                            del self.receive_buffer[channel]
-                        return message
-                    except asyncio.TimeoutError:
-                        # See if we need to propagate a dead receiver exception
-                        if self.receive_loop_task.done():
-                            self.receive_loop_task.result()
+                        message_channel, message = await self.receive_single(real_channel)
+                        await self.receive_buffer[message_channel].put(message)
+                    finally:
+                        await self.receive_tokens.put(token)
+
+                # We know there's a message available, because there
+                # couldn't have been any interruption between empty() and here
+                message = self.receive_buffer[channel].get_nowait()
+                if self.receive_buffer[channel].empty():
+                    del self.receive_buffer[channel]
+                return message
 
             finally:
                 self.receive_count -= 1
                 # If we were the last out, stop the receive loop
                 if self.receive_count == 0:
-                    self.receive_loop_task.cancel()
+                    self.receive_tokens = None
         else:
             # Do a plain direct receive
             return (await self.receive_single(channel))[1]
-
-    async def receive_loop(self, general_channel):
-        """
-        Continuous-receiving loop that makes sure something is fetching results
-        for the channel passed in.
-        """
-        assert general_channel.endswith("!"), "receive_loop not called on general queue of process-local channel"
-        while True:
-            real_channel, message = await self.receive_single(general_channel)
-            await self.receive_buffer[real_channel].put(message)
 
     async def receive_single(self, channel):
         """


### PR DESCRIPTION
This pull request mainly deals with adding connection pools to the Channels layer and fixing the fallout from using them in the tests.

Further, a race condition is fixed when receiving special messages from Redis. There is a short discussion in the commit's log.